### PR TITLE
remove hard coded reference to iglu central on the raw links

### DIFF
--- a/src/components/SchemaRow.tsx
+++ b/src/components/SchemaRow.tsx
@@ -123,7 +123,7 @@ const SchemaRow: FC<SchemaRowProps> = ({ schema }) => {
             </Box>
           </Link>
           <Link
-            href={`//iglucentral.com/schemas/${schema.fullName}/${schema.type}/${schema.version}`}
+            href={`/schemas/${schema.fullName}/${schema.type}/${schema.version}`}
             target={"_blank"}
             onClick={() =>
               trackInteraction("click", "link", `${schema.name}-raw`)


### PR DESCRIPTION
The raw links were hard coded to iglucentral.com. Removes the domain from the url and converts to a relative link