### PR TITLE
allow search links

### DIFF
--- a/src/components/SchemaList.tsx
+++ b/src/components/SchemaList.tsx
@@ -56,9 +56,14 @@ const MemoizedSchemaTable = memo(SchemaTable);
 
 type SchemaListProps = {
   schemas: Schema[];
+  filterText: string;
+  onFilterTextChanged: (filterText: string) => void;
 };
-const SchemaList: FC<SchemaListProps> = ({ schemas }) => {
-  const [filterText, setFilterText] = useState("");
+const SchemaList: FC<SchemaListProps> = ({
+  schemas,
+  filterText,
+  onFilterTextChanged,
+}) => {
   const [filter] = useDebounce(filterText, 200);
   const [renderCount, setRenderCount] = useState(DEFAULT_NUMBER_TO_RENDER);
   const trackInteraction = useTrackInteraction();
@@ -110,7 +115,9 @@ const SchemaList: FC<SchemaListProps> = ({ schemas }) => {
           <TextField
             value={filterText}
             onFocus={() => trackInteraction("focus", "textbox", "search")}
-            onChange={(e) => setFilterText(e.target.value)}
+            onChange={({ target: { value } }) => {
+              onFilterTextChanged(value);
+            }}
             sx={{
               width: "100%",
               backgroundColor: (theme) => theme.palette.common.white,

--- a/src/components/SchemaList.tsx
+++ b/src/components/SchemaList.tsx
@@ -9,7 +9,7 @@ import {
 import { FC, useMemo, useState, memo } from "react";
 import { Schema } from "../data/types";
 import { useTrackInteraction } from "./Snowplow";
-import SchemaRow, { SchemaHeaderRow } from "./SchemaRow";
+import SchemaRow, { SchemaHeaderRow, SchemaEmptyRow } from "./SchemaRow";
 import { useDebounce } from "use-debounce";
 
 const DEFAULT_NUMBER_TO_RENDER = 50;
@@ -29,7 +29,7 @@ const SchemaTable: FC<{ schemas: Schema[] }> = ({ schemas }) => (
     <SchemaHeaderRow />
     <TableBody
       sx={{
-        "&>tr:nth-of-type(odd)": {
+        "&>tr:nth-of-type(even)": {
           backgroundColor: {
             xs: "#F0EBF8",
             lg: "revert",
@@ -41,9 +41,13 @@ const SchemaTable: FC<{ schemas: Schema[] }> = ({ schemas }) => (
         },
       }}
     >
-      {schemas.map((s) => (
-        <SchemaRow key={`${s.fullName}${s.version}`} schema={s} />
-      ))}
+      {schemas.length === 0 ? (
+        <SchemaEmptyRow />
+      ) : (
+        schemas.map((s) => (
+          <SchemaRow key={`${s.fullName}${s.version}`} schema={s} />
+        ))
+      )}
     </TableBody>
   </Table>
 );

--- a/src/components/SchemaRow.tsx
+++ b/src/components/SchemaRow.tsx
@@ -5,6 +5,8 @@ import {
   TableRow,
   TableCell,
   TableHead,
+  Alert,
+  AlertTitle,
 } from "@mui/material";
 import { FC, PropsWithChildren } from "react";
 import { Schema } from "../data/types";
@@ -29,6 +31,34 @@ export const SchemaHeaderRow = () => (
       <TableCell>View</TableCell>
     </TableRow>
   </TableHead>
+);
+
+export const SchemaEmptyRow: FC = () => (
+  <TableRow
+    sx={{
+      display: {
+        xs: "block",
+        lg: "revert",
+      },
+      padding: 2,
+    }}
+  >
+    <TableCell
+      sx={{
+        display: {
+          xs: "block",
+          lg: "revert",
+        },
+        border: 0,
+      }}
+      colSpan={5}
+    >
+      <Alert severity="info">
+        <AlertTitle>No schemas found</AlertTitle>No schemas found with the
+        current query.
+      </Alert>
+    </TableCell>
+  </TableRow>
 );
 
 const SchemaCell: FC<PropsWithChildren<{ label: string }>> = ({

--- a/src/containers/SchemasPage.tsx
+++ b/src/containers/SchemasPage.tsx
@@ -8,11 +8,16 @@ import Loader from "../components/Loader";
 
 const SchemasPage = () => {
   const [schemas, setSchemas] = useState<Schema[] | undefined>(undefined);
-
+  const [filterText, setFilterText] = useState("");
   useEffect(() => {
     getSchemas()
       .then((schemas) => setSchemas(schemas))
       .catch(() => setSchemas([]));
+  }, []);
+
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    setFilterText(params.get("q") || "");
   }, []);
 
   return (
@@ -28,7 +33,14 @@ const SchemasPage = () => {
           <Loader />
         </Box>
       ) : (
-        <SchemaList schemas={schemas} />
+        <SchemaList
+          filterText={filterText}
+          onFilterTextChanged={(f) => {
+            setFilterText(f);
+            window.history.replaceState("", "", `?q=${f}`);
+          }}
+          schemas={schemas}
+        />
       )}
     </Page>
   );

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -1,4 +1,5 @@
 import { createTheme } from "@mui/material";
+import { common } from "@mui/material/colors";
 
 const fontWeight = {
   light: 300,
@@ -70,6 +71,125 @@ const theme = createTheme({
       styleOverrides: {
         root: {
           textTransform: "none",
+        },
+      },
+    },
+    MuiAlert: {
+      styleOverrides: {
+        root: {
+          padding: "0px",
+          borderRadius: "none",
+        },
+        message: {
+          width: "100%",
+          padding: ".75rem 16px",
+        },
+        icon: {
+          padding: "0.75rem 8px 0.75rem 8px",
+          marginRight: 0,
+        },
+        standardError: {
+          "& > .MuiAlert-message": {
+            color: common.black,
+            backgroundColor: "#FCEBE9",
+            "& > p": {
+              marginTop: "0.35rem",
+            },
+          },
+          "& > .MuiAlert-icon": {
+            color: common.black,
+            backgroundColor: "#DD3327",
+            fontSize: "24px",
+          },
+          "& > .MuiAlert-action": {
+            padding: "12px 16px 0px 16px",
+            marginRight: 0,
+            "& > .MuiButtonBase-root.MuiIconButton-root": {
+              padding: 0,
+              "& > .MuiSvgIcon-root": {
+                fontSize: "24px",
+              },
+            },
+          },
+        },
+        standardWarning: {
+          backgroundColor: "#FFEEBA",
+          "& > .MuiAlert-message": {
+            color: common.black,
+            "& > p": {
+              marginTop: "0.35rem",
+            },
+          },
+          "& > .MuiAlert-icon": {
+            color: common.black,
+            backgroundColor: "#FFC107",
+            fontSize: "24px",
+          },
+          "& > .MuiAlert-action": {
+            padding: "12px 16px 0px 16px",
+            marginRight: 0,
+            "& > .MuiButtonBase-root.MuiIconButton-root": {
+              padding: 0,
+              "& > .MuiSvgIcon-root": {
+                fontSize: "24px",
+              },
+            },
+          },
+        },
+        standardInfo: {
+          backgroundColor: "#E6F6FE",
+          "& > .MuiAlert-message": {
+            color: common.black,
+            "& > p": {
+              marginBottom: "8px",
+            },
+          },
+          "& > .MuiAlert-icon": {
+            color: common.black,
+            backgroundColor: "#03A9F4",
+            fontSize: "24px",
+          },
+          "& > .MuiAlert-action": {
+            padding: "12px 16px 0px 16px",
+            marginRight: 0,
+            "& > .MuiButtonBase-root.MuiIconButton-root": {
+              padding: 0,
+              "& > .MuiSvgIcon-root": {
+                fontSize: "24px",
+              },
+            },
+          },
+        },
+        standardSuccess: {
+          backgroundColor: "#CDE9CE",
+          "& > .MuiAlert-message": {
+            color: common.black,
+            "& > p": {
+              marginTop: "0.35rem",
+            },
+          },
+          "& > .MuiAlert-icon": {
+            color: common.black,
+            backgroundColor: "#4CAF50",
+            fontSize: "24px",
+          },
+          "& > .MuiAlert-action": {
+            padding: "12px 16px 0px 16px",
+            marginRight: 0,
+            "& > .MuiButtonBase-root.MuiIconButton-root": {
+              padding: 0,
+              "& > .MuiSvgIcon-root": {
+                fontSize: "24px",
+              },
+            },
+          },
+        },
+      },
+    },
+    MuiAlertTitle: {
+      styleOverrides: {
+        root: {
+          margin: 0,
         },
       },
     },


### PR DESCRIPTION
Allows a user to deep link to a particular query i.e. `/?q=com.snowplow` and the application will pre-filter the results. Also implements an empty state on the filtered list to make it more obvious there are no schemas matching the current query.