### PR TITLE
Show full schema in modal

### DIFF
--- a/src/components/SchemaModal.tsx
+++ b/src/components/SchemaModal.tsx
@@ -144,13 +144,6 @@ const SchemaModal: FC<SchemaModalProps> = ({
 }) => {
   const [tab, setTab] = useState(0);
 
-  const schema = {
-    $schema: rawSchema?.$schema,
-    self: rawSchema?.self,
-    type: rawSchema?.type,
-    properties: rawSchema?.properties,
-  };
-
   return (
     <StyledDialog
       onClose={onClose}
@@ -211,7 +204,7 @@ const SchemaModal: FC<SchemaModalProps> = ({
                     </Box>
                     <CodePanel
                       language={"json"}
-                      code={JSON.stringify(schema, null, 2)}
+                      code={JSON.stringify(rawSchema, null, 2)}
                     />
                   </TabPanel>
 

--- a/src/containers/SchemasPage.tsx
+++ b/src/containers/SchemasPage.tsx
@@ -7,17 +7,13 @@ import SchemaList from "../components/SchemaList";
 import Loader from "../components/Loader";
 
 const SchemasPage = () => {
+  const params = new URLSearchParams(window.location.search);
   const [schemas, setSchemas] = useState<Schema[] | undefined>(undefined);
-  const [filterText, setFilterText] = useState("");
+  const [filterText, setFilterText] = useState(params.get("q") || "");
   useEffect(() => {
     getSchemas()
       .then((schemas) => setSchemas(schemas))
       .catch(() => setSchemas([]));
-  }, []);
-
-  useEffect(() => {
-    const params = new URLSearchParams(window.location.search);
-    setFilterText(params.get("q") || "");
   }, []);
 
   return (


### PR DESCRIPTION
- removes the redeclaration of the schema object to prune some of the fields and just show the whole schema
- Grabs the search query on the initial load rather